### PR TITLE
Trajectory encoders

### DIFF
--- a/gridcells/data/dataset.py
+++ b/gridcells/data/dataset.py
@@ -19,4 +19,23 @@ class SelfLocationDataset(Dataset):
         batch_id = idx // 10_000
         trajectory_id = idx % 10_000
         trajectory = self.batch_trajectories[batch_id][trajectory_id]
+
         return trajectory.as_dict()
+
+
+class EncodedLocationDataset(SelfLocationDataset):
+    def __init__(self, paths: list[Path], encoder: None):
+        super().__init__(paths=paths)
+        self.encoder = encoder
+
+    def __getitem__(self, idx: int) -> dict:
+        trajectory = super().__getitem__(idx)
+        encoded_position = self.encoder.encode_positions(trajectory)
+        encoded_head_direction = self.encoder.encode_head_direction(trajectory)
+
+        record = {
+            'position': encoded_position,
+            'encoded_head_direction': encoded_head_direction,
+        }
+
+        return record

--- a/gridcells/data/encoder.py
+++ b/gridcells/data/encoder.py
@@ -1,0 +1,75 @@
+import numpy as np
+from scipy.special import logsumexp
+from gridcells.data.structures import Trajectory
+
+
+SEED = 8341
+
+
+class DeepMindishEncoder:
+    def __init__(self, n_place_cells: int = 256, n_head_cells: int = 12):
+        self.place_encoder = DeepMindPlaceEncoder(n_cells=n_place_cells)
+        self.head_direction_encoder = DeepMindHeadEncoder(n_cells=n_head_cells)
+
+    def encode(self, trajectory: Trajectory):
+        initial_conditions = {
+            'position': self.place_encoder.encode(trajectory.init_pos[np.newaxis, :]),
+            'head_direction': self.head_direction_encoder.encode(trajectory.init_hd),
+        }
+
+        targets = {
+            'position': self.place_encoder.encode(trajectory.target_pos),
+            'head_direction': self.head_direction_encoder.encode(trajectory.target_hd),
+        }
+
+        record = {
+            'initial_conditions': initial_conditions,
+            'targets': targets,
+        }
+        return record
+
+
+class DeepMindHeadEncoder:
+    def __init__(self, n_cells: int = 12):
+        self.n_cells = n_cells
+
+        concentration = 20
+
+        rs = np.random.RandomState(SEED)
+        self.means = rs.uniform(-np.pi, np.pi, (n_cells))
+        self.kappa = np.ones_like(self.means) * concentration
+
+    def encode(self, head_direction: np.array) -> np.array:
+        logp = self.kappa * np.cos(head_direction - self.means[np.newaxis, np.newaxis, :])
+        log_posteriors = logp - logsumexp(logp, axis=2, keepdims=True)
+        return log_posteriors
+
+
+class DeepMindPlaceEncoder:
+    def __init__(self, n_cells: int = 256):
+        self.n_cells = n_cells
+
+        # Hard coded settings used in the original repo
+        pos_min = -1.1
+        pos_max = 1.1
+        stdev = 0.01
+
+        rs = np.random.RandomState(SEED)
+        self.means = rs.uniform(pos_min, pos_max, size=(n_cells, 2))
+        self.variances = np.ones_like(self.means) * stdev**2
+
+    def encode(self, trajs: np.array):
+        diff = trajs[:, np.newaxis, np.newaxis, :] - self.means[np.newaxis, np.newaxis, ...]
+        normalized_diff = (diff**2) / self.variances
+
+        logp = -0.5 * np.sum(normalized_diff, axis=-1)
+
+        log_posteriors = logp - logsumexp(logp, axis=2, keepdims=True)
+        # probs = softmax(log_posteriors)
+
+        return log_posteriors
+
+    def decode(self, x: np.array) -> np.array:
+        idxs = x[:, 0, :].argmax(-1)
+        recreated = np.array([self.means[idx] for idx in idxs])
+        return recreated

--- a/gridcells/main.py
+++ b/gridcells/main.py
@@ -1,4 +1,5 @@
 import torch
+import numpy as np
 from tqdm import tqdm
 from glob import glob
 import datetime as dt
@@ -6,6 +7,7 @@ import torch.nn as nn
 from torch.utils.data import DataLoader
 from torch.utils.tensorboard import SummaryWriter
 
+from gridcells.data import encoder as data_encoder
 from gridcells.models import main as gridcell_models
 from gridcells.data.dataset import SelfLocationDataset
 from gridcells.training import epochs as training_epochs
@@ -87,6 +89,15 @@ def write_validation_plots(
             model_head=head_cells[idx].detach(),
         )
         writer.add_figure(f"validation/trajectories/{idx:02}", fig, epoch)
+
+
+def review_encoding():
+    paths = glob('data/torch/*pt')
+    dataset = SelfLocationDataset(paths[:1])
+    idx = np.random.randint(len(dataset))
+    target_pos = dataset[idx]['target_pos']
+    position_encoder = data_encoder.DeepMindPlaceEncoder()
+    validation_views.review_position_encoder(target_pos, position_encoder)
 
 
 if __name__ == '__main__':

--- a/gridcells/validation/views.py
+++ b/gridcells/validation/views.py
@@ -38,3 +38,19 @@ def compare_model_output(
     fig.tight_layout()
 
     return fig
+
+
+def review_position_encoder(positions: np.array, encoder):
+    encoded = encoder.encode(positions)
+    decoded = encoder.decode(encoded)
+
+    fig, ax = plt.subplots(1, 1, figsize=(6, 6))
+    ax.plot(positions[:, 0], positions[:, 1], label='trajectory')
+    # ax.scatter(decoded[:, 0], decoded[:, 1], label='decoded')
+    # ax.plot(positions[:, 0], positions[:, 1])
+    ax.plot(decoded[:, 0], decoded[:, 1], '-o', label='decoded', color='tomato')
+
+    ax.set_xlim(-1.1, 1.1)
+    ax.set_ylim(-1.1, 1.1)
+
+    ax.legend()


### PR DESCRIPTION
The encoding procedure is (supposed to be) one-to-one with the original deep-mind code.

Steps to run encoding review (see the code in `gridcells.main.review_encoding` for details):

```python
def show():
    plt.tight_layout()
    plt.savefig('tmp/tmp.png')
    plt.clf()

from gridcells import main as gc

gc.review_encoding()
show()
```

Sample outputs:
<img width="300" alt="image" src="https://user-images.githubusercontent.com/8056825/185598360-42036f16-3b7e-41a0-aa17-8148628d870f.png">

<img width="300" alt="image" src="https://user-images.githubusercontent.com/8056825/185598868-00a1244b-8e8c-433d-8873-051a1378027f.png">

<img width="300" alt="image" src="https://user-images.githubusercontent.com/8056825/185598964-35676fbf-9730-4b36-af30-83f952432782.png">


