### PR TITLE
Remove encoding cache

### DIFF
--- a/gridcells/data/encoder.py
+++ b/gridcells/data/encoder.py
@@ -37,7 +37,12 @@ class DeepMindHeadEncoder:
         self.kappa = np.ones_like(self.means) * concentration
 
     def encode(self, head_direction: np.array) -> np.array:
-        logp = self.kappa * np.cos(head_direction - self.means[np.newaxis, :])
+        if len(head_direction.shape) == 3:
+            # It's a batch
+            logp = self.kappa * np.cos(head_direction - self.means[np.newaxis, np.newaxis, :])
+        else:
+            # It's a single trajectory (2 dim)
+            logp = self.kappa * np.cos(head_direction - self.means[np.newaxis, :])
         log_posteriors = logp - logsumexp(logp, axis=1, keepdims=True)
 
         probs = softmax(log_posteriors, axis=-1)
@@ -63,7 +68,13 @@ class DeepMindPlaceEncoder:
         self.variances = np.ones_like(self.means) * stdev ** 2
 
     def encode(self, trajs: np.array):
-        diff = trajs[:, np.newaxis, :] - self.means[np.newaxis, ...]
+        if len(trajs.shape) == 3:
+            # It's a batch
+            diff = trajs[:, :, np.newaxis, :] - self.means[np.newaxis, np.newaxis, ...]
+        else:
+            # It's a single trajectory (2 dim)
+            diff = trajs[:, np.newaxis, :] - self.means[np.newaxis, ...]
+
         normalized_diff = (diff ** 2) / self.variances
 
         logp = -0.5 * np.sum(normalized_diff, axis=-1)
@@ -75,6 +86,6 @@ class DeepMindPlaceEncoder:
         return probs.astype(np.float32)
 
     def decode(self, x: np.array) -> np.array:
-        idxs = x[:, :].argmax(-1)
+        idxs = x.argmax(-1)
         recreated = np.array([self.means[idx] for idx in idxs])
         return recreated

--- a/gridcells/training/deepmind/epochs.py
+++ b/gridcells/training/deepmind/epochs.py
@@ -29,9 +29,7 @@ def train_epoch(
     loss_metric = LossMetric()
 
     batches_per_epoch = samples_per_epoch / data_loader.batch_size
-    # progress_bar = tqdm(data_loader, total=len(data_loader), leave=False)
     progress_bar = tqdm(enumerate(data_loader), total=batches_per_epoch, leave=False)
-    # for batch in data_loader:
     for it, batch in progress_bar:
         optimizer.zero_grad()
 
@@ -58,14 +56,16 @@ def validation_epoch(
     model: nn.Module,
     data_loader: DataLoader,
     device: torch.device,
+    samples_per_epoch: int,
 ) -> float:
     model.eval()
 
     loss_metric = LossMetric()
 
-    # for batch in data_loader:
-    progress_bar = tqdm(data_loader, total=len(data_loader), leave=False)
-    for batch in progress_bar:
+    # progress_bar = tqdm(data_loader, total=len(data_loader), leave=False)
+    batches_per_epoch = samples_per_epoch / data_loader.batch_size
+    progress_bar = tqdm(enumerate(data_loader), total=batches_per_epoch, leave=False)
+    for it, batch in progress_bar:
         loss = process(model, batch, device)
 
         loss_metric.total_loss += loss.item()
@@ -73,6 +73,8 @@ def validation_epoch(
 
         desc = f"Validation Loss: {loss.item():.2f}"
         progress_bar.set_description(desc)
+        if it >= batches_per_epoch:
+            break
 
     return loss_metric.average_loss
 


### PR DESCRIPTION
The benefits from having a cached dataset turned out to be small, and it blocked any experiments with different encoding methods/settings.